### PR TITLE
program map links now behave more nicely

### DIFF
--- a/src/components/Program/ProgramMap.tsx
+++ b/src/components/Program/ProgramMap.tsx
@@ -46,7 +46,7 @@ const ProgramMap: FunctionComponent<{ programs: Program[], week: string }> = ({ 
       <h3>
         <nav>
           <li>
-            <NavLink to='/programs/map/1' exact>Viikko 1</NavLink>
+            <NavLink to='/programs/map/' exact>Viikko 1</NavLink>
           </li>
           <li>
             <NavLink to='/programs/map/2' exact>Viikko 2</NavLink>

--- a/src/views/Programs.tsx
+++ b/src/views/Programs.tsx
@@ -92,7 +92,7 @@ const Programs: FunctionComponent<ProgramsProps> = ({ programs }) => (
           <NavLink to='/programs/' exact>Lista</NavLink>
         </li>
         <li>
-          <NavLink to='/programs/map/' exact>Kartta</NavLink>
+          <NavLink to='/programs/map/'>Kartta</NavLink>
         </li>
       </nav>
     </h2>


### PR DESCRIPTION
"Kartta" is never active if any of the three weeks is shown. "Viikko 1" is inactive when navigating to /programs/map. 

The page served in /programs/map/1 looks a bit dumb though: the link "Viikko 1" is still active.