### PR TITLE
Fix https://github.com/wappuradio/webbi2019/issues/66

### DIFF
--- a/src/style/_map.scss
+++ b/src/style/_map.scss
@@ -5,7 +5,17 @@
   grid-gap: 4px;
   justify-items:center;
   align-items:center;
+  
+  @include responsive(medium,max){
+	font-size: 80%;
+	grid-template-rows: repeat(25, 20px);
+  }
 
+  @include responsive(small,max){
+	font-size: 60%;
+	grid-template-rows: repeat(25, 16px);
+  }
+  
   .map-day
   {
 	  color:white;
@@ -36,7 +46,10 @@
 	height:100%;
 	display:inline-grid;
 	justify-items:center;
-
+	@include responsive(small,max){
+		line-height: 16px;
+	}
+	
   }
 
   .map-program
@@ -55,6 +68,13 @@
 
 	font-size:70%;
 	font-weight:200;
+	@include responsive(small,max){
+		font-size: 90%;
+	}
+	@include responsive(medium,max){
+		font-size: 90%;
+	}
+	
   }
 
   .map-program-active, .map-program-active + .map-program-split

--- a/src/style/_top-bar.scss
+++ b/src/style/_top-bar.scss
@@ -5,12 +5,11 @@
   left: 0;
   right: 0;
   z-index: 1;
-
-  @include responsive(medium) {
-    display: flex;
-    justify-content: space-between;
-  }
-
+  max-width: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  
   audio {
     display: none;
     height: 32px;
@@ -31,9 +30,12 @@
   nav {
     @include t(caps);
     display: flex;
+    flex:auto;
+    align-items: end;
     list-style: none;
     line-height: 2rem;
     &.-main {
+      max-width: 100%;
       a {
         @include transition('background');
         padding: 0.25em 0.5em;
@@ -56,6 +58,18 @@
           border-radius: 0;
         }
       }
+      @include responsive(small, max) {
+        li:first-child{
+          max-width: calc(100% - 277px);
+        }
+        li:first-child div{
+          display: flex;
+          align-items: center;
+          max-width: 100%;
+        }
+        justify-content: center;
+      }
+      
     }
     &.-social {
       justify-content: flex-end;
@@ -97,6 +111,9 @@
         .icontext {
           margin: 1em 0.5em;
         }
+      }
+      @include responsive(small, max){
+        justify-content: center;
       }
     }
   }

--- a/src/style/_vars.scss
+++ b/src/style/_vars.scss
@@ -92,8 +92,8 @@ $typography: (
 
 $breakpoints: (
   small: 32rem,
-  medium: 56rem,
-  large: 60rem,
+  medium: 65rem,
+  large: 68rem,
   xlarge: 72rem
 );
 


### PR DESCRIPTION
Logo text now scales smaller when needed.
Set the top bar to automatically flow row down when no space. Adjust resolution breakpoints to match current some counts. Center align header when double row on phone.